### PR TITLE
feat: Cybereason EDR MCP サーバーを追加

### DIFF
--- a/cybereason-mcp/.env.example
+++ b/cybereason-mcp/.env.example
@@ -1,0 +1,15 @@
+# -----------------------------------------------------------------------
+# Cybereason EDR MCP Server – 環境変数設定
+# このファイルをコピーして .env を作成し、実際の値を設定してください。
+# cp .env.example .env
+# -----------------------------------------------------------------------
+
+# Cybereason テナント URL（末尾スラッシュなし）
+CYBEREASON_URL=https://jpn-sales-demo2.cybereason.net
+
+# ログイン認証情報
+CYBEREASON_USERNAME=your-username@example.com
+CYBEREASON_PASSWORD=your-password
+
+# SSL証明書検証（本番環境では true を推奨。自己署名証明書の場合は false）
+CYBEREASON_VERIFY_SSL=true

--- a/cybereason-mcp/Dockerfile
+++ b/cybereason-mcp/Dockerfile
@@ -1,0 +1,25 @@
+# -----------------------------------------------------------------------
+# Cybereason EDR MCP Server – Dockerfile
+# -----------------------------------------------------------------------
+FROM python:3.12-slim AS base
+
+# 非rootユーザーで実行
+RUN groupadd --gid 1000 appuser \
+    && useradd --uid 1000 --gid appuser --shell /bin/bash --create-home appuser
+
+WORKDIR /app
+
+# 依存関係を先にインストール（キャッシュ効率化）
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# アプリケーションコードをコピー
+COPY server.py cybereason_client.py ./
+
+# 非rootユーザーに切り替え
+USER appuser
+
+# stdio トランスポートを使用するため EXPOSE は不要
+# MCP ホスト（Claude Desktop / claude CLI）が stdin/stdout で接続する
+
+ENTRYPOINT ["python", "server.py"]

--- a/cybereason-mcp/README.md
+++ b/cybereason-mcp/README.md
@@ -1,0 +1,99 @@
+# Cybereason EDR MCP Server
+
+Cybereason EDRのアラート（Malop）をClaudeで分析するためのMCPサーバーです。
+
+## 提供ツール
+
+| ツール名 | 説明 |
+|---|---|
+| `get_alerts` | 未対応アラート（Malop）の一覧取得 |
+| `get_malop_details` | 特定Malopの詳細情報取得 |
+| `get_affected_machines` | Malopに関連する影響マシン一覧 |
+| `update_alert_status` | Malopのステータス更新 |
+
+## セットアップ
+
+### 1. 環境変数の設定
+
+```bash
+cp .env.example .env
+# .env を編集して認証情報を入力
+```
+
+```env
+CYBEREASON_URL=https://jpn-sales-demo2.cybereason.net
+CYBEREASON_USERNAME=your-username@example.com
+CYBEREASON_PASSWORD=your-password
+CYBEREASON_VERIFY_SSL=true
+```
+
+### 2. Dockerイメージのビルド
+
+```bash
+docker compose build
+```
+
+### 3. Claude Desktop / claude CLI への登録
+
+#### Claude Desktop (`claude_desktop_config.json`)
+
+```json
+{
+  "mcpServers": {
+    "cybereason": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "--env-file", "/absolute/path/to/cybereason-mcp/.env",
+        "cybereason-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+#### claude CLI (`.mcp.json` / `mcp add`)
+
+```bash
+claude mcp add cybereason \
+  docker run --rm -i --env-file /absolute/path/to/.env cybereason-mcp:latest
+```
+
+## ローカル開発（Docker なし）
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env   # 認証情報を設定
+python server.py
+```
+
+## アーキテクチャ
+
+```
+Claude (MCP Host)
+    │  stdin / stdout
+    ▼
+server.py          ← MCPサーバー（ツール定義・ルーティング）
+    │  HTTP セッション
+    ▼
+cybereason_client.py  ← REST APIクライアント（セッション認証・自動再ログイン）
+    │  HTTPS
+    ▼
+Cybereason テナント
+```
+
+### 認証フロー
+
+1. 初回ツール呼び出し時に `/rest/login` へ POST してセッションCookieを取得
+2. 以降のリクエストはCookieを自動付与
+3. 401 レスポンスを受けた場合は自動で再ログインしてリトライ
+
+## ステータス値
+
+| 値 | 意味 |
+|---|---|
+| `TODO` | 未対応（デフォルト） |
+| `OPEN` | 対応中 |
+| `UNREAD` | 未読 |
+| `CLOSED` | クローズ済み |
+| `FP` | 誤検知（False Positive） |

--- a/cybereason-mcp/cybereason_client.py
+++ b/cybereason-mcp/cybereason_client.py
@@ -1,0 +1,257 @@
+"""
+Cybereason EDR API Client
+Session-based authentication with automatic re-login on session expiry.
+"""
+
+import logging
+import os
+from typing import Any, Optional
+
+import requests
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+logger = logging.getLogger(__name__)
+
+
+class CybereasonClient:
+    """Client for the Cybereason EDR REST API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        username: str,
+        password: str,
+        verify_ssl: bool = True,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.username = username
+        self.password = password
+        self.verify_ssl = verify_ssl
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Authentication
+    # ------------------------------------------------------------------
+
+    def login(self) -> None:
+        """Authenticate and store the session cookie."""
+        url = f"{self.base_url}/rest/login"
+        payload = {
+            "username": self.username,
+            "password": self.password,
+        }
+        # Cybereason login uses form-encoded data, not JSON
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        resp = self.session.post(
+            url,
+            data=payload,
+            headers=headers,
+            verify=self.verify_ssl,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        logger.info("Cybereason login successful")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        retry_on_401: bool = True,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """Send a request, re-authenticating once on 401."""
+        url = f"{self.base_url}{path}"
+        resp = self.session.request(
+            method, url, verify=self.verify_ssl, timeout=60, **kwargs
+        )
+        if resp.status_code == 401 and retry_on_401:
+            logger.info("Session expired – re-authenticating")
+            self.login()
+            resp = self.session.request(
+                method, url, verify=self.verify_ssl, timeout=60, **kwargs
+            )
+        resp.raise_for_status()
+        return resp
+
+    # ------------------------------------------------------------------
+    # Tool: get_alerts
+    # ------------------------------------------------------------------
+
+    def get_alerts(
+        self,
+        status_filter: Optional[list[str]] = None,
+        limit: int = 25,
+    ) -> dict[str, Any]:
+        """
+        Retrieve unresolved Malops (alerts) from Cybereason.
+
+        Parameters
+        ----------
+        status_filter:
+            List of malop statuses to filter by.
+            Defaults to ["TODO"] (未対応).
+        limit:
+            Maximum number of malops to return (default 25).
+        """
+        if status_filter is None:
+            status_filter = ["TODO"]
+
+        payload: dict[str, Any] = {
+            "totalResultLimit": limit,
+            "perGroupLimit": limit,
+            "perFeatureLimit": limit,
+            "templateContext": "OVERVIEW",
+            "queryPath": [
+                {
+                    "requestedType": "MalopProcess",
+                    "filters": [
+                        {
+                            "facetName": "malopActivityType",
+                            "values": ["MALICIOUS_ACTIVITY"],
+                        }
+                    ],
+                    "connectionFeature": {
+                        "elementInstanceType": "MalopProcess",
+                        "featureName": "suspects",
+                    },
+                }
+            ],
+        }
+
+        if status_filter:
+            payload["queryPath"][0]["filters"].append(  # type: ignore[index]
+                {"facetName": "status", "values": status_filter}
+            )
+
+        resp = self._request(
+            "POST",
+            "/rest/crimes/unified",
+            json=payload,
+        )
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # Tool: get_malop_details
+    # ------------------------------------------------------------------
+
+    def get_malop_details(self, malop_id: str) -> dict[str, Any]:
+        """
+        Retrieve detailed information for a specific Malop.
+
+        Parameters
+        ----------
+        malop_id:
+            The GUID of the Malop (e.g. "11.2345678901234567890").
+        """
+        payload = {
+            "malopGuid": malop_id,
+            "requestedType": "MalopProcess",
+        }
+        resp = self._request(
+            "POST",
+            "/rest/crimes/get-details",
+            json=payload,
+        )
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # Tool: get_affected_machines
+    # ------------------------------------------------------------------
+
+    def get_affected_machines(self, malop_id: str) -> dict[str, Any]:
+        """
+        List machines affected by a specific Malop.
+
+        Parameters
+        ----------
+        malop_id:
+            The GUID of the Malop.
+        """
+        payload: dict[str, Any] = {
+            "queryPath": [
+                {
+                    "requestedType": "Machine",
+                    "filters": [],
+                    "connectionFeature": {
+                        "elementInstanceType": "MalopProcess",
+                        "featureName": "affectedMachines",
+                    },
+                    "isResult": True,
+                },
+                {
+                    "requestedType": "MalopProcess",
+                    "filters": [
+                        {
+                            "facetName": "guid",
+                            "values": [malop_id],
+                        }
+                    ],
+                },
+            ],
+            "totalResultLimit": 1000,
+            "perGroupLimit": 100,
+            "perFeatureLimit": 100,
+            "templateContext": "SPECIFIC",
+            "queryTimeout": 120000,
+        }
+        resp = self._request(
+            "POST",
+            "/rest/crimes/unified",
+            json=payload,
+        )
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # Tool: update_alert_status
+    # ------------------------------------------------------------------
+
+    def update_alert_status(
+        self,
+        malop_id: str,
+        status: str,
+        comment: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """
+        Update the status of a Malop.
+
+        Parameters
+        ----------
+        malop_id:
+            The GUID of the Malop.
+        status:
+            New status. One of: TODO, CLOSED, FP (false positive),
+            OPEN, UNREAD.
+        comment:
+            Optional comment to add when updating the status.
+        """
+        valid_statuses = {"TODO", "CLOSED", "FP", "OPEN", "UNREAD"}
+        if status not in valid_statuses:
+            raise ValueError(
+                f"Invalid status '{status}'. Must be one of: {', '.join(sorted(valid_statuses))}"
+            )
+
+        payload: dict[str, Any] = {
+            "malopId": malop_id,
+            "newStatus": status,
+        }
+        if comment:
+            payload["comment"] = comment
+
+        resp = self._request(
+            "POST",
+            "/rest/crimes/update-status",
+            json=payload,
+        )
+        # Some Cybereason versions return 200 with an empty body on success
+        try:
+            return resp.json()
+        except ValueError:
+            return {"status": "ok", "malopId": malop_id, "newStatus": status}

--- a/cybereason-mcp/docker-compose.yml
+++ b/cybereason-mcp/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.9"
+
+services:
+  cybereason-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: cybereason-mcp:latest
+    container_name: cybereason-mcp
+    restart: unless-stopped
+
+    # stdio トランスポートを使うため、コンテナを対話モードで起動
+    stdin_open: true
+    tty: false
+
+    env_file:
+      - .env
+
+    environment:
+      # .env の値を上書きしたい場合はここに記述
+      # CYBEREASON_VERIFY_SSL: "false"
+      PYTHONUNBUFFERED: "1"
+
+    # ログ設定
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/cybereason-mcp/requirements.txt
+++ b/cybereason-mcp/requirements.txt
@@ -1,0 +1,4 @@
+mcp>=1.0.0
+requests>=2.31.0
+python-dotenv>=1.0.0
+urllib3>=2.0.0

--- a/cybereason-mcp/server.py
+++ b/cybereason-mcp/server.py
@@ -1,0 +1,256 @@
+"""
+Cybereason EDR – MCP Server
+Exposes Cybereason alert management as MCP tools for Claude.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from typing import Any
+
+from dotenv import load_dotenv
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import (
+    CallToolRequest,
+    CallToolResult,
+    ListToolsRequest,
+    ListToolsResult,
+    TextContent,
+    Tool,
+)
+
+from cybereason_client import CybereasonClient
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger("cybereason-mcp")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+load_dotenv()
+
+BASE_URL = os.environ.get("CYBEREASON_URL", "https://jpn-sales-demo2.cybereason.net")
+USERNAME = os.environ.get("CYBEREASON_USERNAME", "")
+PASSWORD = os.environ.get("CYBEREASON_PASSWORD", "")
+VERIFY_SSL = os.environ.get("CYBEREASON_VERIFY_SSL", "true").lower() != "false"
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
+
+TOOLS: list[Tool] = [
+    Tool(
+        name="get_alerts",
+        description=(
+            "Cybereasonから未対応アラート（Malop）の一覧を取得します。"
+            " status_filter で絞り込み可能（デフォルトは TODO のみ）。"
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "status_filter": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["TODO", "OPEN", "UNREAD", "CLOSED", "FP"],
+                    },
+                    "description": (
+                        "取得するアラートのステータスリスト。"
+                        " 省略時は ['TODO'] （未対応のみ）。"
+                    ),
+                    "default": ["TODO"],
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "取得件数の上限（デフォルト 25、最大 1000）。",
+                    "default": 25,
+                    "minimum": 1,
+                    "maximum": 1000,
+                },
+            },
+        },
+    ),
+    Tool(
+        name="get_malop_details",
+        description=(
+            "指定した Malop ID の詳細情報（攻撃手法、IOC、タイムライン等）を取得します。"
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "malop_id": {
+                    "type": "string",
+                    "description": (
+                        "対象 Malop の GUID。"
+                        " 例: '11.2345678901234567890'"
+                    ),
+                }
+            },
+            "required": ["malop_id"],
+        },
+    ),
+    Tool(
+        name="get_affected_machines",
+        description="指定した Malop に関連する影響マシンの一覧を取得します。",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "malop_id": {
+                    "type": "string",
+                    "description": "対象 Malop の GUID。",
+                }
+            },
+            "required": ["malop_id"],
+        },
+    ),
+    Tool(
+        name="update_alert_status",
+        description=(
+            "Malop のステータスを更新します。"
+            " 対応済みクローズや誤検知（FP）マークなどに使用します。"
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "malop_id": {
+                    "type": "string",
+                    "description": "対象 Malop の GUID。",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["TODO", "OPEN", "UNREAD", "CLOSED", "FP"],
+                    "description": (
+                        "新しいステータス。"
+                        " TODO=未対応, OPEN=対応中, CLOSED=クローズ, FP=誤検知。"
+                    ),
+                },
+                "comment": {
+                    "type": "string",
+                    "description": "ステータス変更時のコメント（任意）。",
+                },
+            },
+            "required": ["malop_id", "status"],
+        },
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Server setup
+# ---------------------------------------------------------------------------
+
+app = Server("cybereason-mcp")
+_client: CybereasonClient | None = None
+
+
+def get_client() -> CybereasonClient:
+    """Return a lazily-initialised, authenticated Cybereason client."""
+    global _client
+    if _client is None:
+        if not USERNAME or not PASSWORD:
+            raise RuntimeError(
+                "CYBEREASON_USERNAME および CYBEREASON_PASSWORD 環境変数を設定してください。"
+            )
+        _client = CybereasonClient(
+            base_url=BASE_URL,
+            username=USERNAME,
+            password=PASSWORD,
+            verify_ssl=VERIFY_SSL,
+        )
+        _client.login()
+        logger.info("Cybereason クライアント初期化完了: %s", BASE_URL)
+    return _client
+
+
+def _json_text(data: Any) -> TextContent:
+    """Serialize data as pretty-printed JSON TextContent."""
+    return TextContent(
+        type="text",
+        text=json.dumps(data, ensure_ascii=False, indent=2),
+    )
+
+
+# ---------------------------------------------------------------------------
+# MCP handlers
+# ---------------------------------------------------------------------------
+
+
+@app.list_tools()
+async def list_tools(_: ListToolsRequest) -> ListToolsResult:  # type: ignore[name-defined]
+    return ListToolsResult(tools=TOOLS)
+
+
+@app.call_tool()
+async def call_tool(request: CallToolRequest) -> CallToolResult:  # type: ignore[name-defined]
+    name = request.params.name
+    args: dict[str, Any] = request.params.arguments or {}
+
+    logger.info("ツール呼び出し: %s  引数: %s", name, args)
+
+    try:
+        client = get_client()
+
+        if name == "get_alerts":
+            result = await asyncio.to_thread(
+                client.get_alerts,
+                status_filter=args.get("status_filter"),
+                limit=args.get("limit", 25),
+            )
+
+        elif name == "get_malop_details":
+            malop_id: str = args["malop_id"]
+            result = await asyncio.to_thread(client.get_malop_details, malop_id)
+
+        elif name == "get_affected_machines":
+            malop_id = args["malop_id"]
+            result = await asyncio.to_thread(client.get_affected_machines, malop_id)
+
+        elif name == "update_alert_status":
+            result = await asyncio.to_thread(
+                client.update_alert_status,
+                malop_id=args["malop_id"],
+                status=args["status"],
+                comment=args.get("comment"),
+            )
+
+        else:
+            raise ValueError(f"未知のツール: {name}")
+
+        return CallToolResult(content=[_json_text(result)])
+
+    except Exception as exc:
+        logger.exception("ツール '%s' の実行中にエラーが発生しました", name)
+        error_payload = {
+            "error": type(exc).__name__,
+            "message": str(exc),
+        }
+        return CallToolResult(
+            content=[_json_text(error_payload)],
+            isError=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+async def main() -> None:
+    logger.info("Cybereason MCP サーバーを起動します (stdio トランスポート)")
+    async with stdio_server() as (read_stream, write_stream):
+        await app.run(read_stream, write_stream, app.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Cybereason EDR のアラートを Claude で分析するための MCP サーバーを追加。

## 提供ツール
- get_alerts: 未対応アラート（Malop）の一覧取得
- get_malop_details: 特定 Malop の詳細情報取得
- get_affected_machines: 影響マシン一覧取得
- update_alert_status: Malop ステータス更新

## 構成
- cybereason_client.py: セッションベース認証付き REST API クライアント（401 自動再ログイン）
- server.py: MCP サーバー（stdio トランスポート）
- Dockerfile: Python 3.12-slim ベース、非 root 実行
- docker-compose.yml: .env ファイル連携
- .env.example: 環境変数テンプレート

https://claude.ai/code/session_01UNu8jfaoqxjBYq7NBZw3qD